### PR TITLE
[fix] 구글 소셜 로그인 인증 에러 해결

### DIFF
--- a/src/main/java/com/hibit2/hibit2/infrastructure/oauth/client/GoogleOAuthClient.java
+++ b/src/main/java/com/hibit2/hibit2/infrastructure/oauth/client/GoogleOAuthClient.java
@@ -86,12 +86,12 @@ public class GoogleOAuthClient implements OAuthClient {
         return new String(Base64.getUrlDecoder().decode(payload), StandardCharsets.UTF_8);
     }
 
-    // 수정 필요 -> userInfo - 이메일, 성별, 나이 담아야 함
+    // 수정 완료
     private OAuthMember generateOAuthMemberBy(final String decodedIdToken) throws JsonProcessingException {
         Map<String, String> userInfo = objectMapper.readValue(decodedIdToken, HashMap.class);
         String email = userInfo.get("email");
         String gender = userInfo.get("gender");
-        int age = userInfo.get("age");
+        int age = Integer.parseInt(userInfo.get("age"));
 
         return new OAuthMember(email, gender, age);
     }


### PR DESCRIPTION
* [x] 🙆🏻 PR 제목 형식은 지켰는가? ex. `[feat] 소셜로그인 기능을 구현한다.`
* [x] 💯 테스트는 통과했나?
* [x] ✅ 빌드는 성공했나?
* [x] 🧹 불필요한 코드는 제거했나?
* [x] 💭 이슈는 등록했는가?
* [x] 🔖 라벨은 등록했나? ex. `feat`, `devops`

## 작업 내용

* [x] GoogleOAuthClient 클래스내의 `generateOAuthMemberBy` 메서드에서 age 변수를 Integer.parseInt로 구현하여 에러를 수정했습니다.

* Closes #12 