### PR TITLE
[feat] 프로필 정보를 조회하는 기능을 구현한다. 

### DIFF
--- a/src/main/java/com/hibit2/hibit2/auth/support/UserAuthenticationPrincipal.java
+++ b/src/main/java/com/hibit2/hibit2/auth/support/UserAuthenticationPrincipal.java
@@ -1,0 +1,12 @@
+package com.hibit2.hibit2.auth.support;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UserAuthenticationPrincipal {
+
+}

--- a/src/main/java/com/hibit2/hibit2/exception/NotFoundException.java
+++ b/src/main/java/com/hibit2/hibit2/exception/NotFoundException.java
@@ -1,0 +1,8 @@
+package com.hibit2.hibit2.exception;
+
+public class NotFoundException extends RuntimeException{
+
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/hibit2/hibit2/member/domain/Member.java
+++ b/src/main/java/com/hibit2/hibit2/member/domain/Member.java
@@ -14,6 +14,7 @@ import javax.persistence.Table;
 
 import com.hibit2.hibit2.member.exception.InvalidMemberException;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Table(name = "members")
@@ -27,10 +28,12 @@ public class Member {
     private Long id;
 
     @Column(name = "email", nullable = false)
+    @Schema(description = "이메일", example = "teamhibit@gmail.com")
     private String email;
 
     @Enumerated(value = EnumType.STRING)
     @Column(name = "social_type", nullable = false)
+    @Schema(description = "소셜 로그인 유형", example = "GOOGLE")
     private SocialType socialType;
 
     protected Member() {

--- a/src/main/java/com/hibit2/hibit2/profile/controller/ProfileController.java
+++ b/src/main/java/com/hibit2/hibit2/profile/controller/ProfileController.java
@@ -5,19 +5,22 @@ import java.net.URI;
 import javax.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.hibit2.hibit2.auth.support.UserAuthenticationPrincipal;
 import com.hibit2.hibit2.profile.dto.request.RegisterProfileRequest;
 import com.hibit2.hibit2.profile.dto.response.RegisterProfileResponse;
+import com.hibit2.hibit2.profile.dto.response.UserProfileResponse;
 import com.hibit2.hibit2.profile.service.ProfileService;
 
 import io.swagger.v3.oas.annotations.Operation;
 
 @RestController
-@RequestMapping("/profiles")
+@RequestMapping("/api/profiles")
 public class ProfileController {
 
     private final ProfileService profileService;
@@ -28,11 +31,19 @@ public class ProfileController {
 
     // 프로필 등록
     @PostMapping
-    @Operation(summary = "/profiles/1", description = "프로필 등록")
+    @Operation(summary = "/profiles/{profile.getId()}", description = "프로필 등록")
     public ResponseEntity<Void> registerProfile(@Valid @RequestBody RegisterProfileRequest registerProfileRequest) {
 
         RegisterProfileResponse profile = profileService.registerProfile(registerProfileRequest);
 
         return ResponseEntity.created(URI.create("/profiles/" + profile.getId())).build();
+    }
+
+    // 프로필 조회
+    @GetMapping
+    @Operation(summary = "/me/profile", description = "프로필 조회")
+    public ResponseEntity<UserProfileResponse> getProfile(@UserAuthenticationPrincipal int profileId) {
+        UserProfileResponse response = profileService.getProfile(profileId);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/hibit2/hibit2/profile/domain/Profile.java
+++ b/src/main/java/com/hibit2/hibit2/profile/domain/Profile.java
@@ -11,7 +11,6 @@ import java.util.regex.Pattern;
 import com.hibit2.hibit2.member.domain.Member;
 
 @Table(name = "profiles")
-@Getter
 @Entity
 public class Profile {
 
@@ -90,5 +89,53 @@ public class Profile {
         this.addressCity = addressCity;
         this.addressDistinct = addressDistinct;
         this.ban = ban;
+    }
+
+    public Member getMember() {
+        return member;
+    }
+
+    public int getIdx() {
+        return idx;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    public int getGender() {
+        return gender;
+    }
+
+    public List<PersonalityType> getPersonality() {
+        return personality;
+    }
+
+    public String getIntroduce() {
+        return introduce;
+    }
+
+    public List<ProfileImage> getMainImg() {
+        return mainImg;
+    }
+
+    public String getJob() {
+        return job;
+    }
+
+    public AddressCity getAddressCity() {
+        return addressCity;
+    }
+
+    public AddressDistinct getAddressDistinct() {
+        return addressDistinct;
+    }
+
+    public int getBan() {
+        return ban;
     }
 }

--- a/src/main/java/com/hibit2/hibit2/profile/dto/request/RegisterProfileRequest.java
+++ b/src/main/java/com/hibit2/hibit2/profile/dto/request/RegisterProfileRequest.java
@@ -28,7 +28,7 @@ public class RegisterProfileRequest {
     private int age;
 
     @NotBlank
-    @Schema(description = "성별", example = "남성")
+    @Schema(description = "성별", example = "0")
     private int gender;
 
     @NotBlank

--- a/src/main/java/com/hibit2/hibit2/profile/dto/response/UserProfileResponse.java
+++ b/src/main/java/com/hibit2/hibit2/profile/dto/response/UserProfileResponse.java
@@ -1,0 +1,59 @@
+package com.hibit2.hibit2.profile.dto.response;
+
+import java.util.List;
+
+import com.hibit2.hibit2.profile.domain.AddressCity;
+import com.hibit2.hibit2.profile.domain.AddressDistinct;
+import com.hibit2.hibit2.profile.domain.PersonalityType;
+import com.hibit2.hibit2.profile.domain.Profile;
+import com.hibit2.hibit2.profile.domain.ProfileImage;
+
+import lombok.Getter;
+
+@Getter
+public class UserProfileResponse {
+
+    // 필수 노출 정보
+    private String nickname;
+    private int gender;
+    private List<PersonalityType> personality;
+    private String introduce;
+    private List<ProfileImage> mainImg;
+
+    // 선택 노출 정보
+    private int age;
+    private AddressCity addressCity;
+    private AddressDistinct addressDistinct;
+    private String job;
+
+    // @NoArgsConstructor(access = AccessLevel.PRIVATE) : 아무런 매개변수가 없는 생성자
+    // dto - AccessLevel.PRIVATE / entity - AccessLevel.PROTECTED
+    public UserProfileResponse() {
+    }
+
+    // @AllArgsConstructor(access = AccessLevel.PRIVATE) : 해당 클래스 내의 모든 변수값을 가진 생성자를 자동으로 만들어 준다.
+    public UserProfileResponse(String nickname, int gender, List<PersonalityType> personality, String introduce,
+        List<ProfileImage> mainImg, int age, AddressCity addressCity, AddressDistinct addressDistinct, String job) {
+        this.nickname = nickname;
+        this.gender = gender;
+        this.personality = personality;
+        this.introduce = introduce;
+        this.mainImg = mainImg;
+        this.age = age;
+        this.addressCity = addressCity;
+        this.addressDistinct = addressDistinct;
+        this.job = job;
+    }
+
+    public UserProfileResponse(Profile profile) {
+        this(profile.getNickname(),
+            profile.getGender(),
+            profile.getPersonality(),
+            profile.getIntroduce(),
+            profile.getMainImg(),
+            profile.getIdx(),
+            profile.getAddressCity(),
+            profile.getAddressDistinct(),
+            profile.getJob());
+    }
+}

--- a/src/main/java/com/hibit2/hibit2/profile/exception/NotFoundProfileException.java
+++ b/src/main/java/com/hibit2/hibit2/profile/exception/NotFoundProfileException.java
@@ -1,0 +1,12 @@
+package com.hibit2.hibit2.profile.exception;
+
+import com.hibit2.hibit2.exception.NotFoundException;
+
+public class NotFoundProfileException extends NotFoundException {
+
+    private static final String ERROR_MESSAGE = "존재하지 않는 프로필입니다.";
+
+    public NotFoundProfileException() {
+        super(ERROR_MESSAGE);
+    }
+}

--- a/src/main/java/com/hibit2/hibit2/profile/service/ProfileService.java
+++ b/src/main/java/com/hibit2/hibit2/profile/service/ProfileService.java
@@ -6,6 +6,8 @@ import org.springframework.transaction.annotation.Transactional;
 import com.hibit2.hibit2.profile.domain.Profile;
 import com.hibit2.hibit2.profile.dto.request.RegisterProfileRequest;
 import com.hibit2.hibit2.profile.dto.response.RegisterProfileResponse;
+import com.hibit2.hibit2.profile.dto.response.UserProfileResponse;
+import com.hibit2.hibit2.profile.exception.NotFoundProfileException;
 import com.hibit2.hibit2.profile.repository.ProfileRepository;
 
 
@@ -37,4 +39,9 @@ public class ProfileService {
         return new RegisterProfileResponse(saveProfile);
     }
 
+    public UserProfileResponse getProfile(int profileId) {
+        Profile profile = profileRepository.findById(profileId)
+            .orElseThrow(NotFoundProfileException::new);
+        return new UserProfileResponse(profile);
+    }
 }

--- a/src/test/java/com/hibit2/hibit2/profile/controller/ProfileControllerTest.java
+++ b/src/test/java/com/hibit2/hibit2/profile/controller/ProfileControllerTest.java
@@ -1,0 +1,20 @@
+package com.hibit2.hibit2.profile.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ProfileControllerTest {
+
+    @DisplayName("유저가 자신의 프로필 조회에 성공한다.")
+    @Test
+    void 유저가_자신의_프로필_조회에_성공한다() throws Exception {
+        // given
+
+        // when
+
+        // then
+
+    }
+}


### PR DESCRIPTION
- [x] 🙆🏻 PR 제목 형식은 지켰는가? ex. `[feat] 소셜로그인 기능을 구현한다.`
- [ ] 💯 테스트는 통과했나?
- [x] ✅ 빌드는 성공했나?
- [x] 🧹 불필요한 코드는 제거했나?
- [x] 💭 이슈는 등록했는가?
- [x] 🔖 라벨은 등록했나? ex. `feat`, `devops`

## 작업 내용

- 유저 자신의 프로필을 조회하는 기능을 구현했습니다.
- 현재 개발한 로직에는 **유저 자신의 프로필 정보**를 들어간 경우, **필수-선택 상관없이 모두 보여지도록 구현**했습니다. 필수-선택 정보에 대한 구분 여부는 이후에 추가로 구현할 예정입니다.

## 관련 이슈

- Closes #10 

## To Reviewer

- 유저에 대한 프로필 id 값을 가져올 때 Spring Security와 같은 보안 프레임워크를 사용하여 사용자 정보를 추출하여 파라미터로 전달하는 작업을 수행하는 대신, **`@UserAuthenticationPrincipal` 어노테이션을 커스텀화하여 사용**했습니다. `@UserAuthenticationPrincipal` 어노테이션은 실제로 `profileId` 파라미터를 현재 인증된 사용자의 식별자로 자동으로 주입하는 역할을 수행하며, `profileService.getProfile(profileId)` 를 호출하여 해당 코치의 프로필 정보를 가져온 뒤, ResponseEntity로 래핑하여 반환하는 역할을 합니다.
- 따라서 이러한 **`커스텀 어노테이션`**을 사용함으로써 **컨트롤러 코드를 간결하고 가독성있게 유지할 수 있으며, 인증된 사용자 정보를 편리하게 활용**할 수 있습니다.
- 현재 시점에서 프로젝트 마감까지 시간이 얼마 없기 때문에, **기능 구현이 우선적으로 끝내야 하는 상황**이라 프로필에 대한 `테스트 코드`는 **기능 구현이 모두 완료한 이후에 추가할 예정**입니다.
