### PR TITLE
[소셜 로그인] 리프레시 토큰을 발급하는 과정에서 에러 해결

### DIFF
--- a/src/main/java/com/hibit2/hibit2/auth/domain/OAuthToken.java
+++ b/src/main/java/com/hibit2/hibit2/auth/domain/OAuthToken.java
@@ -16,7 +16,7 @@ public class OAuthToken extends BaseTimeEntity {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "members_id", nullable = false)
     private Member member;
-    @Column(name = "refresh_token", nullable = false)
+    @Column(name = "refresh_token")
     private String refreshToken;
 
     protected OAuthToken() {


### PR DESCRIPTION
## 에러 발생 원인
에러 메시지 분석 - not-null property references a null or transient value
> 에러는 다음 2가지 경우로 인해 발생하게 된다.
- [1] nullable = false 로 표시된 열에 대해 null 값을 저장할 때
- [2] 저장되지 않은 인스턴스를 참조하는 연관이 있는 엔티티를 저장할 때
- 즉, 회원가입 하지 않았을 경우 refreshToken 값이 없는데, 해당 값을 참조해서 회원 엔티티를 저장하니까 에러가 발생한 거였다.

## 해결 과정

기존에 refreshToken @Column 부분에 nullable = false 을 삭제 해주면 된다. 그러면 refreshToken이 없을 경우에도 엔티티를 생성할 때 액세스 토큰과 리플레시 토큰을 발급하므로 에러가 발생하지 않는다

처음 로그인/회원가입 할 경우 refresh token 값이 없으므로, 관련 엔티티 클래스인 `OAuthToken`에서 nullable를 false인 부분 삭제 -> `@Column(name = "refresh_token")` 

<img width="1000" alt="oauth-google-oauthProvider-token-error-resolve" src="https://github.com/hibit-team/hibit-backend/assets/83820185/2df20884-2a10-48d7-a5f8-37465227f39a">

해당 엔티티를 수정하고 다시 실행시켜보니, 성공하게 되었다.

## 관련 이슈

- Close #44 