### PR TITLE
[소셜 로그인] 본인 로그인 조회 에러 해결

### DIFF
--- a/src/main/java/com/hibit2/hibit2/auth/presentation/AuthenticationPrincipalArgumentResolver.java
+++ b/src/main/java/com/hibit2/hibit2/auth/presentation/AuthenticationPrincipalArgumentResolver.java
@@ -3,7 +3,6 @@ package com.hibit2.hibit2.auth.presentation;
 import javax.servlet.http.HttpServletRequest;
 
 import org.springframework.core.MethodParameter;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;

--- a/src/main/java/com/hibit2/hibit2/member/controller/MemberController.java
+++ b/src/main/java/com/hibit2/hibit2/member/controller/MemberController.java
@@ -1,14 +1,13 @@
 package com.hibit2.hibit2.member.controller;
 
+import com.hibit2.hibit2.auth.dto.LoginMember;
+import com.hibit2.hibit2.auth.presentation.AuthenticationPrincipal;
+import com.hibit2.hibit2.member.service.MemberService;
+import com.hibit2.hibit2.member.dto.MemberResponse;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import com.hibit2.hibit2.auth.dto.LoginMember;
-import com.hibit2.hibit2.member.dto.MemberResponse;
-import com.hibit2.hibit2.member.service.MemberService;
 
 @RequestMapping("/api/members")
 @RestController


### PR DESCRIPTION
## 에러 내용
- #46
- `com.hibit2.hibit2.auth.exception.EmptyAuthorizationHeaderException: null`

## 해결 과정

<img width="1000" alt="본인로그인조회_에러1_MemberController" src="https://github.com/hibit-team/hibit-backend/assets/83820185/0738a299-c540-4d84-b089-e4ee7574d142">

- 기존에 MemberController 에서 `@AuthenticationPrincipal` 어노테이션을 스프링 시큐리티를 사용했다.
- 하지만, AuthController에서 사용했던 `@AuthenticationPrincipal` 어노테이션은 자체적으로 내가 만든 어노테이션을 가져왔다.

<img width="350" alt="인증인가_자체개발" src="https://github.com/hibit-team/hibit-backend/assets/83820185/5b7ef00a-b7fd-4160-909a-9df31db69d4d">

- 히빗 서비스 개발 부분에서 **인증/인가** 부분은 스프링 시큐리티를 사용 없이 `Authenticationprincipal` 커스텀화해서 자체 개발했기 때문에, MemberController에서 스프링 시큐리티를 import하는 것이 아니라 AuthController과 동일하게 어노테이션을 사용해야만 제대로 동작하게 된다.

## 확인 작업

### 본인 로그인 조회 - 1

<img width="600" alt="본인로그인조회_해결_1Authorize" src="https://github.com/hibit-team/hibit-backend/assets/83820185/de4a4696-8981-4b3f-8f9d-30f389294905">

- swagger 문서에서 Authorize 버튼 클릭

### 본인 로그인 조회 - 2

<img width="600" alt="본인로그인조회_해결_2액세스토큰값" src="https://github.com/hibit-team/hibit-backend/assets/83820185/83013de6-d432-4aad-85a6-29b2f1a43d33">

- 안에 Value 값에 로그인/회원가입에서 발급 받은 **액세스 토큰 값**을 넣고, Authorize 클릭한다.

### 본인 로그인 조회 - 3

<img width="600" alt="본인로그인조회_해결_3로그인완료" src="https://github.com/hibit-team/hibit-backend/assets/83820185/a4e75121-0e2b-4113-bdeb-dc73bbec38f6">

- 그러면 로그인이 완료되고, AuthController 부분에서 회원가입이 되었는지 조회해서 확인한다.

### 구글 소셜 로그인 회원가입 확인 - AuthController

<img width="1000" alt="구글_소셜로그인_토큰으로_회원가입_확인" src="https://github.com/hibit-team/hibit-backend/assets/83820185/e582063a-f78b-431c-b579-dc18beff562f">

- 액세스토큰으로 로그인한 본인을 조회하면 위와 같이 200(성공)이 된다.

### 구글 소셜 로그인 본인 조회 확인 - MemberController

<img width="1000" alt="구글_소셜로그인_본인조회_확인" src="https://github.com/hibit-team/hibit-backend/assets/83820185/68ea0017-c5cb-4651-bd5d-e082d032fd5a">

- MemberController 역시 본인을 조회하면 다음과 같이 email과 소셜 로그인 유형(여기선 구글)이 성공적으로 조회가 나온다.


