### PR TITLE
[feat] 회원가입할때 구글로부터 닉네임, 프로필 이미지를 가져오도록 구현

### DIFF
--- a/src/main/java/com/hibit2/hibit2/auth/dto/OAuthMember.java
+++ b/src/main/java/com/hibit2/hibit2/auth/dto/OAuthMember.java
@@ -6,11 +6,17 @@ import com.hibit2.hibit2.member.domain.SocialType;
 public class OAuthMember {
 
     private final String email;
+
+    private final String displayName;
+    private final String profileImageUrl;
+
     private final String refreshToken;
 
 
-    public OAuthMember(String email, String refreshToken) {
+    public OAuthMember(String email, String displayName, String profileImageUrl, String refreshToken) {
         this.email = email;
+        this.displayName = displayName;
+        this.profileImageUrl = profileImageUrl;
         this.refreshToken = refreshToken;
     }
 
@@ -18,12 +24,19 @@ public class OAuthMember {
         return email;
     }
 
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getProfileImageUrl() {
+        return profileImageUrl;
+    }
     public String getRefreshToken() {
         return refreshToken;
     }
 
     public Member toMember() {
-        return new Member(email, SocialType.GOOGLE);
+        return new Member(email, displayName, profileImageUrl, SocialType.GOOGLE);
     }
 
 }

--- a/src/main/java/com/hibit2/hibit2/global/config/properties/GoogleProperties.java
+++ b/src/main/java/com/hibit2/hibit2/global/config/properties/GoogleProperties.java
@@ -4,6 +4,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.ConstructorBinding;
 
+import java.util.List;
+
 @ConfigurationProperties("oauth.google")
 @ConstructorBinding
 public class GoogleProperties {
@@ -11,7 +13,7 @@ public class GoogleProperties {
     private final String clientSecret;
     private final String oAuthEndPoint;
     private final String responseType;
-    private final String scopes;
+    private final List<String> scopes;
     private final String tokenUri;
     private final String accessType;
 
@@ -19,7 +21,7 @@ public class GoogleProperties {
                             @Value("${oauth.google.client-secret}") final String clientSecret,
                             @Value("${oauth.google.oauth-end-point}") final String oAuthEndPoint,
                             @Value("${oauth.google.response-type}") final String responseType,
-                            @Value("${oauth.google.scopes}") final String scopes,
+                            @Value("${oauth.google.scopes}") final List<String> scopes,
                             @Value("${oauth.google.token-uri}") final String tokenUri,
                             @Value("${oauth.google.access-type}") final String accessType) {
         this.clientId = clientId;
@@ -47,7 +49,7 @@ public class GoogleProperties {
         return responseType;
     }
 
-    public String getScopes() {
+    public List<String> getScopes() {
         return scopes;
     }
 

--- a/src/main/java/com/hibit2/hibit2/infrastructure/oauth/client/GoogleOAuthClient.java
+++ b/src/main/java/com/hibit2/hibit2/infrastructure/oauth/client/GoogleOAuthClient.java
@@ -48,7 +48,7 @@ public class GoogleOAuthClient implements OAuthClient {
         UserInfo userInfo = parseUserInfo(payload);
 
         String refreshToken = googleTokenResponse.getRefreshToken();
-        return new OAuthMember(userInfo.getEmail(), refreshToken);
+        return new OAuthMember(userInfo.getEmail(), userInfo.getName(), userInfo.getPicture(), refreshToken);
     }
 
     private GoogleTokenResponse requestGoogleToken(final String code, final String redirectUri) {

--- a/src/main/java/com/hibit2/hibit2/infrastructure/oauth/dto/UserInfo.java
+++ b/src/main/java/com/hibit2/hibit2/infrastructure/oauth/dto/UserInfo.java
@@ -5,12 +5,15 @@ public class UserInfo {
     private String email;
     private String name;
 
+    private String picture;
+
     private UserInfo() {
     }
 
-    public UserInfo(final String email, final String name, final String picture) {
+    public UserInfo(String email, String name, String picture) {
         this.email = email;
         this.name = name;
+        this.picture = picture;
     }
 
     public String getEmail() {
@@ -21,4 +24,7 @@ public class UserInfo {
         return name;
     }
 
+    public String getPicture() {
+        return picture;
+    }
 }

--- a/src/main/java/com/hibit2/hibit2/member/domain/Member.java
+++ b/src/main/java/com/hibit2/hibit2/member/domain/Member.java
@@ -21,6 +21,7 @@ import lombok.Getter;
 @Entity
 public class Member {
     private static final Pattern EMAIL_PATTERN = Pattern.compile("^[a-z0-9._-]+@[a-z]+[.]+[a-z]{2,3}$");
+    private static final int MAX_DISPLAY_NAME_LENGTH = 100;
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")
@@ -30,6 +31,12 @@ public class Member {
     @Schema(description = "이메일", example = "teamhibit@gmail.com")
     private String email;
 
+    @Column(name = "display_name", nullable = false)
+    private String displayName;
+
+    @Column(name = "profile_image_url", nullable = false)
+    private String profileImageUrl;
+
     @Enumerated(value = EnumType.STRING)
     @Column(name = "social_type", nullable = false)
     @Schema(description = "소셜 로그인 유형", example = "GOOGLE")
@@ -38,10 +45,14 @@ public class Member {
     protected Member() {
     }
 
-    public  Member(final String email, final SocialType socialType) {
+    public Member(String email, String displayName, String profileImageUrl, SocialType socialType) {
+
         validateEmail(email);
+        validateDisplayName(displayName);
 
         this.email = email;
+        this.displayName = displayName;
+        this.profileImageUrl = profileImageUrl;
         this.socialType = socialType;
     }
 
@@ -52,6 +63,11 @@ public class Member {
         }
     }
 
+    private void validateDisplayName(final String displayName) {
+        if (displayName.isEmpty() || displayName.length() > MAX_DISPLAY_NAME_LENGTH) {
+            throw new InvalidMemberException(String.format("이름은 1자 이상 1자 %d이하여야 합니다.", MAX_DISPLAY_NAME_LENGTH));
+        }
+    }
     public Long getId() {
         return id;
     }
@@ -60,6 +76,13 @@ public class Member {
         return email;
     }
 
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getProfileImageUrl() {
+        return profileImageUrl;
+    }
     public SocialType getSocialType() {
         return socialType;
     }

--- a/src/main/java/com/hibit2/hibit2/member/dto/MemberResponse.java
+++ b/src/main/java/com/hibit2/hibit2/member/dto/MemberResponse.java
@@ -7,16 +7,22 @@ public class MemberResponse {
 
     private Long id;
     private String email;
+
+    private String displayName;
+    private String profileImageUrl;
     private SocialType socialType;
 
-    public MemberResponse(final Long id, final String email, final SocialType socialType) {
+    public MemberResponse(Long id, String email, String displayName, String profileImageUrl, SocialType socialType) {
         this.id = id;
         this.email = email;
+        this.displayName = displayName;
+        this.profileImageUrl = profileImageUrl;
         this.socialType = socialType;
     }
 
     public MemberResponse(final Member member) {
-        this(member.getId(), member.getEmail(), member.getSocialType());
+        this(member.getId(), member.getEmail(), member.getDisplayName(), member.getProfileImageUrl(),
+                member.getSocialType());
     }
 
     public Long getId() {
@@ -25,6 +31,14 @@ public class MemberResponse {
 
     public String getEmail() {
         return email;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getProfileImageUrl() {
+        return profileImageUrl;
     }
 
     public SocialType getSocialType() {

--- a/src/test/java/com/hibit2/hibit2/common/Constants.java
+++ b/src/test/java/com/hibit2/hibit2/common/Constants.java
@@ -2,4 +2,8 @@ package com.hibit2.hibit2.common;
 
 public class Constants {
     public static final String 팬시_이메일 = "fancy@email.com";
+
+    public static final String 팬시_이름 = "fancy";
+
+    public static final String 팬시_프로필_URL = "/fancy.png";
 }

--- a/src/test/java/com/hibit2/hibit2/common/OAuthFixtures.java
+++ b/src/test/java/com/hibit2/hibit2/common/OAuthFixtures.java
@@ -30,24 +30,32 @@ public enum OAuthFixtures {
 
     private static OAuthMember 관리자() {
         String 관리자_이메일 = "hibit.admin@gmail.com";
+        String 관리자_이름 = "관리자";
+        String 관리자_프로필 = "/hibit-admin.png";
         String 관리자_REFRESH_TOKEN = "aaaaaaaaaa.bbbbbbbbbb.cccccccccc";
-        return new OAuthMember(관리자_이메일, 관리자_REFRESH_TOKEN);
+        return new OAuthMember(관리자_이메일, 관리자_이름, 관리자_프로필,관리자_REFRESH_TOKEN);
     }
 
     private static OAuthMember 팬시() {
         String 팬시_이메일 = "parang@email.com";
+        String 팬시_이름 = "팬시";
+        String 팬시_프로필 = "/fancy.png";
         String 팬시_REFRESH_TOKEN = "aaaaaaaaaa.bbbbbbbbbb.cccccccccc";
-        return new OAuthMember(팬시_이메일, 팬시_REFRESH_TOKEN);
+        return new OAuthMember(팬시_이메일, 팬시_이름, 팬시_프로필, 팬시_REFRESH_TOKEN);
     }
     private static OAuthMember MEMBER() {
         String MEMBER_이메일 = "member@email.com";
+        String MEMBER_이름 = "member";
+        String MEMBER_프로필 = "/member.png";
         String MEMBER_REFRESH_TOKEN = "aaaaaaaaaa.bbbbbbbbbb.ccccccccc";
-        return new OAuthMember(MEMBER_이메일, MEMBER_REFRESH_TOKEN);
+        return new OAuthMember(MEMBER_이메일, MEMBER_이름, MEMBER_프로필, MEMBER_REFRESH_TOKEN);
     }
     private static OAuthMember CREATOR() {
         String CREATOR_이메일 = "creator@email.com";
+        String CREATOR_이름 = "creator";
+        String CREATOR_프로필 = "/creator.png";
         String CREATOR_REFRESH_TOKEN = "aaaaaaaaaa.bbbbbbbbbb.ccccccccc";
-        return new OAuthMember(CREATOR_이메일, CREATOR_REFRESH_TOKEN);
+        return new OAuthMember(CREATOR_이메일, CREATOR_이름, CREATOR_프로필, CREATOR_REFRESH_TOKEN);
     }
 
     public String getCode() {

--- a/src/test/java/com/hibit2/hibit2/common/annotation/ServiceTest.java
+++ b/src/test/java/com/hibit2/hibit2/common/annotation/ServiceTest.java
@@ -14,7 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
-import static com.hibit2.hibit2.common.Constants.팬시_이메일;
+import static com.hibit2.hibit2.common.Constants.*;
 
 
 @SpringBootTest(classes = ExternalApiConfig.class)
@@ -46,7 +46,7 @@ public abstract class ServiceTest {
 
     protected GivenBuilder 팬시() {
         GivenBuilder 팬시 = new GivenBuilder(builderSupporter);
-        팬시.회원_가입을_한다(팬시_이메일);
+        팬시.회원_가입을_한다(팬시_이메일, 팬시_이름, 팬시_프로필_URL);
         return 팬시;
     }
 }

--- a/src/test/java/com/hibit2/hibit2/common/builder/GivenBuilder.java
+++ b/src/test/java/com/hibit2/hibit2/common/builder/GivenBuilder.java
@@ -14,8 +14,9 @@ public final class GivenBuilder {
         this.bs = bs;
     }
 
-    public GivenBuilder 회원_가입을_한다(final String email) {
-        Member member = new Member(email, SocialType.GOOGLE);
+    public GivenBuilder 회원_가입을_한다(final String email, final String name,
+                                  final String profile) {
+        Member member = new Member(email, name, profile,SocialType.GOOGLE);
         this.member = bs.memberRepository().save(member);
         OAuthToken oAuthToken = new OAuthToken(this.member, "asd");
         bs.oAuthTokenRepository().save(oAuthToken);

--- a/src/test/java/com/hibit2/hibit2/common/fixtures/MemberFixtures.java
+++ b/src/test/java/com/hibit2/hibit2/common/fixtures/MemberFixtures.java
@@ -1,0 +1,29 @@
+package com.hibit2.hibit2.common.fixtures;
+
+import com.hibit2.hibit2.member.domain.Member;
+import com.hibit2.hibit2.member.dto.MemberResponse;
+
+import static com.hibit2.hibit2.member.domain.SocialType.GOOGLE;
+
+public class MemberFixtures {
+
+    /* 관리자 */
+    public static final String 관리자_이메일 = "hibit.admin@gmail.com";
+    public static final String 관리자_이름 = "관리자";
+    public static final String 관리자_프로필 = "/hibit-admin.png";
+    public static final MemberResponse 관리자_응답 = new MemberResponse(1L, 관리자_이메일, 관리자_이름, 관리자_프로필, GOOGLE);
+
+    /* 팬시 */
+    public static final String 팬시_이메일 = "fancy.junyongmoon@gmail.com";
+    public static final String 팬시_이름 = "팬시";
+    public static final String 팬시_프로필 = "/fancy.png";
+    public static final MemberResponse 팬시_응답 = new MemberResponse(2L, 팬시_이메일, 팬시_이름, 팬시_프로필, GOOGLE);
+
+    public static Member 관리자() {
+        return new Member(관리자_이메일, 관리자_이름, 관리자_프로필, GOOGLE);
+    }
+    public static Member 팬시() {
+        return new Member(팬시_이메일, 팬시_이름, 팬시_프로필, GOOGLE);
+    }
+
+}

--- a/src/test/java/com/hibit2/hibit2/member/domain/MemberRepositoryTest.java
+++ b/src/test/java/com/hibit2/hibit2/member/domain/MemberRepositoryTest.java
@@ -8,6 +8,10 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import com.hibit2.hibit2.member.repository.MemberRepository;
 
+import static com.hibit2.hibit2.common.fixtures.MemberFixtures.팬시;
+import static com.hibit2.hibit2.common.fixtures.MemberFixtures.팬시_이메일;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
 @DataJpaTest
 class MemberRepositoryTest {
 
@@ -18,27 +22,23 @@ class MemberRepositoryTest {
     @Test
     void 이메일을_통해_회원을_찾는다() {
         // given
-        String email = "fancy.junyongmoon@gmail.com";
-        Member member = new Member(email, SocialType.GOOGLE);
-        Member savedMember = memberRepository.save(member);
+        Member 팬시 = memberRepository.save(팬시());
 
         // when
-        Member foundMember = memberRepository.findByEmail(email).get();
+        Member actual = memberRepository.getByEmail(팬시_이메일);
 
         // then
-        Assertions.assertThat(savedMember.getId()).isEqualTo(foundMember.getId());
+        assertThat(actual.getId()).isEqualTo(팬시.getId());
     }
 
     @DisplayName("중복된 이메일이 존재하는 경우 true를 반환한다.")
     @Test
     void 중복된_이메일이_존재하는_경우_true를_반환한다() {
         // given
-        String email = "fancy.junyongmoon@gmail.com";
-        Member member = new Member(email, SocialType.GOOGLE);
-        memberRepository.save(member);
+        memberRepository.save(팬시());
 
         // when
-        boolean actual = memberRepository.existsByEmail(email);
+        boolean actual = memberRepository.existsByEmail(팬시_이메일);
 
         // then
         Assertions.assertThat(actual).isTrue();

--- a/src/test/java/com/hibit2/hibit2/member/domain/MemberTest.java
+++ b/src/test/java/com/hibit2/hibit2/member/domain/MemberTest.java
@@ -1,5 +1,8 @@
 package com.hibit2.hibit2.member.domain;
 
+import static com.hibit2.hibit2.common.fixtures.MemberFixtures.팬시_이메일;
+import static com.hibit2.hibit2.common.fixtures.MemberFixtures.팬시_이름;
+import static com.hibit2.hibit2.common.fixtures.MemberFixtures.팬시_프로필;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -8,20 +11,15 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import com.hibit2.hibit2.member.domain.Member;
-import com.hibit2.hibit2.member.domain.SocialType;
 import com.hibit2.hibit2.member.exception.InvalidMemberException;
 
 class MemberTest {
     @DisplayName("회원을 생성한다.")
     @Test
     void 회원을_생성한다() {
-        //given
-        String email = "fancy.junyongmoon@gmail.com";
-        SocialType socialType = SocialType.GOOGLE;
 
-        // when & then
-        assertDoesNotThrow(() -> new Member(email, socialType));
+        // given & when & then
+        assertDoesNotThrow(() -> new Member(팬시_이메일, 팬시_이름, 팬시_프로필, SocialType.GOOGLE));
     }
 
 
@@ -31,7 +29,7 @@ class MemberTest {
     void 회원의_email_형식이_맞지_않으면_예외가_발생한다(final String email) {
 
         // given & when & then
-        assertThatThrownBy(() -> new Member(email, SocialType.GOOGLE))
+        assertThatThrownBy(() -> new Member(email, 팬시_이름, 팬시_프로필, SocialType.GOOGLE))
             .isInstanceOf(InvalidMemberException.class);
     }
 }

--- a/src/test/java/com/hibit2/hibit2/member/service/MemberServiceTest.java
+++ b/src/test/java/com/hibit2/hibit2/member/service/MemberServiceTest.java
@@ -2,6 +2,7 @@ package com.hibit2.hibit2.member.service;
 
 import com.hibit2.hibit2.common.annotation.ServiceTest;
 import com.hibit2.hibit2.common.builder.GivenBuilder;
+import com.hibit2.hibit2.member.repository.MemberRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,50 +21,6 @@ class MemberServiceTest extends ServiceTest {
 
     @Autowired
     private MemberService memberService;
-
-    @DisplayName("회원을 저장한다.")
-    @Test
-    void 회원을_저장한다() {
-        // given
-        Member member = new Member("fancy.junyongmoon@gmail.com", SocialType.GOOGLE);
-
-        // when
-        Member actual = memberService.save(member);
-
-        // then
-        Assertions.assertThat(actual).isNotNull();
-    }
-
-    @DisplayName("이메일로 회원을 찾는다.")
-    @Test
-    void 이메일로_회원을_찾는다() {
-        // given
-        String email = "member@gmail.com";
-        Member member = new Member(email, SocialType.GOOGLE);
-        Member savedMember = memberService.save(member);
-
-        // when
-        Member foundMember = memberService.findByEmail(email);
-
-        // then
-        Assertions.assertThat(foundMember.getId()).isEqualTo(savedMember.getId());
-    }
-
-    @DisplayName("주어진 이메일로 가입된 회원이 있는지 확인한다.")
-    @CsvSource(value = {"registerd@gmail.com,true", "notregistered@naver.com,false"})
-    @ParameterizedTest
-    void 주어진_이메일로_가입된_회원이_있는지_확인한다(String input, boolean expected) {
-        // given
-        String email = "registerd@gmail.com";
-        Member member = new Member(email, SocialType.GOOGLE);
-        memberService.save(member);
-
-        // when
-        boolean actual = memberService.existByEmail(input);
-
-        // then
-        Assertions.assertThat(actual).isEqualTo(expected);
-    }
 
     @DisplayName("회원을 조회한다.")
     @Test

--- a/src/test/java/com/hibit2/hibit2/profile/domain/ProfileTest.java
+++ b/src/test/java/com/hibit2/hibit2/profile/domain/ProfileTest.java
@@ -10,6 +10,11 @@ import org.junit.jupiter.api.Test;
 import com.hibit2.hibit2.member.domain.Member;
 import com.hibit2.hibit2.member.domain.SocialType;
 
+import static com.hibit2.hibit2.common.fixtures.MemberFixtures.팬시_이메일;
+import static com.hibit2.hibit2.common.fixtures.MemberFixtures.팬시_이름;
+import static com.hibit2.hibit2.common.fixtures.MemberFixtures.팬시_프로필;
+
+
 class ProfileTest {
 
 
@@ -18,7 +23,7 @@ class ProfileTest {
     void 프로필을_생성한다() {
         // given
         Long id = 1L;
-        Member member = new Member("fancy.junyongmoon@gmail.com", SocialType.GOOGLE);
+        Member member = new Member(팬시_이메일, 팬시_이름, 팬시_프로필, SocialType.GOOGLE);
         String nickname = "fancy";
         int age = 26;
         int gender = 1;


### PR DESCRIPTION
- [x] 🙆🏻 PR 제목 형식은 지켰는가? ex. `[feat] 소셜로그인 기능을 구현한다.`
- [x] 💯 테스트는 통과했나?
- [x] ✅ 빌드는 성공했나?
- [x] 🧹 불필요한 코드는 제거했나?
- [x] 💭 이슈는 등록했는가?
- [x] 🔖 라벨은 등록했나? ex. `feat`, `devops`


## 작업 내용

- 아래의 관련 이슈에 가보시면 `세부 작업 내용`을 확인해 주시면 됩니다.

## 관련 이슈

- Closes #56 

## 결과 스크린샷

<img width="1000" alt="소셜로그인_회원가입_닉네임_프로필가져오기" src="https://github.com/hibit-team/hibit-backend/assets/83820185/a45f808f-bf00-4c72-b33c-7fe1711431cc">


## To 리뷰어

- 프로필 이미지 뿐만 아니라 닉네임도 가져올 수 있기 때문에, 둘다 추가해서 기능 구현했습니다.
