### PR TITLE
[feat] 닉네임 중복 여부(true/false)에 대한 API 기능 추가 구현

### DIFF
--- a/src/main/java/com/hibit2/hibit2/profile/controller/ProfileController.java
+++ b/src/main/java/com/hibit2/hibit2/profile/controller/ProfileController.java
@@ -7,9 +7,9 @@ import java.util.List;
 import javax.validation.Valid;
 
 import com.hibit2.hibit2.auth.presentation.AuthenticationPrincipal;
+import com.hibit2.hibit2.member.service.MemberService;
 import com.hibit2.hibit2.profile.domain.PersonalityType;
-import com.hibit2.hibit2.profile.dto.response.ProfileOtherResponse;
-import com.hibit2.hibit2.profile.dto.response.ProfilesResponse;
+import com.hibit2.hibit2.profile.dto.response.*;
 import com.hibit2.hibit2.profile.exception.InvalidOtherProfileException;
 import com.hibit2.hibit2.profile.exception.InvalidPersonalityException;
 import com.hibit2.hibit2.profile.exception.NicknameAlreadyTakenException;
@@ -22,8 +22,6 @@ import org.springframework.web.bind.annotation.*;
 import com.hibit2.hibit2.auth.dto.LoginMember;
 import com.hibit2.hibit2.profile.dto.request.ProfileRegisterRequest;
 import com.hibit2.hibit2.profile.dto.request.ProfileUpdateRequest;
-import com.hibit2.hibit2.profile.dto.response.ProfileRegisterResponse;
-import com.hibit2.hibit2.profile.dto.response.ProfileResponse;
 import com.hibit2.hibit2.profile.service.ProfileService;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -123,5 +121,15 @@ public class ProfileController {
 
         profileService.updateProfile(loginMember.getId(), profileUpdateRequest);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+    @GetMapping(value = "/nickname/exists", params = "nickname")
+    public ResponseEntity<UniqueResponse> validateUniqueNickname(@RequestParam String nickname) {
+        try {
+            profileService.validateUniqueNickname(nickname);
+            return ResponseEntity.ok(new UniqueResponse(true));
+        } catch (NicknameAlreadyTakenException ex) {
+            return ResponseEntity.ok(new UniqueResponse(false));
+        }
     }
 }

--- a/src/main/java/com/hibit2/hibit2/profile/domain/Profile.java
+++ b/src/main/java/com/hibit2/hibit2/profile/domain/Profile.java
@@ -23,7 +23,7 @@ public class Profile extends BaseTimeEntity {
     @JoinColumn(name = "members_id")
     private Member member;
 
-    @Column(name = "nickname", length = 20)
+    @Column(name = "nickname", length = 20, unique = true)
     private String nickname;
 
     @Column(name = "age")

--- a/src/main/java/com/hibit2/hibit2/profile/dto/response/UniqueResponse.java
+++ b/src/main/java/com/hibit2/hibit2/profile/dto/response/UniqueResponse.java
@@ -1,0 +1,17 @@
+package com.hibit2.hibit2.profile.dto.response;
+
+import lombok.Getter;
+
+// 중복된 닉네임에 대한 dto
+@Getter
+public class UniqueResponse {
+
+    private boolean unique;
+
+    public UniqueResponse() {
+    }
+
+    public UniqueResponse(boolean unique) {
+        this.unique = unique;
+    }
+}

--- a/src/main/java/com/hibit2/hibit2/profile/service/ProfileService.java
+++ b/src/main/java/com/hibit2/hibit2/profile/service/ProfileService.java
@@ -1,8 +1,7 @@
 package com.hibit2.hibit2.profile.service;
 
 import com.hibit2.hibit2.auth.dto.LoginMember;
-import com.hibit2.hibit2.profile.dto.response.ProfileOtherResponse;
-import com.hibit2.hibit2.profile.dto.response.ProfilesResponse;
+import com.hibit2.hibit2.profile.dto.response.*;
 import com.hibit2.hibit2.profile.exception.NicknameAlreadyTakenException;
 import com.hibit2.hibit2.profile.exception.NotFoundProfileException;
 import org.springframework.stereotype.Service;
@@ -13,8 +12,6 @@ import com.hibit2.hibit2.member.repository.MemberRepository;
 import com.hibit2.hibit2.profile.domain.Profile;
 import com.hibit2.hibit2.profile.dto.request.ProfileRegisterRequest;
 import com.hibit2.hibit2.profile.dto.request.ProfileUpdateRequest;
-import com.hibit2.hibit2.profile.dto.response.ProfileRegisterResponse;
-import com.hibit2.hibit2.profile.dto.response.ProfileResponse;
 import com.hibit2.hibit2.profile.repository.ProfileRepository;
 
 import java.util.List;
@@ -127,5 +124,11 @@ public class ProfileService {
                 .orElseThrow(() -> new NotFoundProfileException("타인의 프로필을 찾을 수 없습니다."));
 
         return new ProfileOtherResponse(profile);
+    }
+
+    public void validateUniqueNickname(String nickname) {
+        if (profileRepository.existsByNickname(nickname)) {
+            throw new NicknameAlreadyTakenException("이미 사용중인 닉네임 입니다.");
+        }
     }
 }


### PR DESCRIPTION
- [x] 🙆🏻 PR 제목 형식은 지켰는가? ex. `[feat] 소셜로그인 기능을 구현한다.`
- [x] ✅ 빌드는 성공했나?
- [x] 🧹 불필요한 코드는 제거했나?
- [x] 💭 이슈는 등록했는가?
- [x] 🔖 라벨은 등록했나? ex. `feat`, `devops`


## 작업 내용
추가된 프로필 API - GetMapping: `/api/profiles/nickname/exists`
- 닉네임 중복 여부(true/false)에 대한 API 기능을 추가 구현했습니다.

## 관련 이슈

- Closes #74 

## To 리뷰어

> 리뷰어에게 하고 싶은말

reponse body의 값을 true/falss로 반환해도 괜찮을까요?
중복된 닉네임을 입력할 경우에는 false, 중복된 닉네임이 없는 경우에는 true로 했습니다!
