### PR TITLE
[refactor] sameSite 설정을 위해 ResponseCookie로 변경

### DIFF
--- a/src/main/java/com/hibit2/hibit2/auth/application/AuthTokenResponseHandler.java
+++ b/src/main/java/com/hibit2/hibit2/auth/application/AuthTokenResponseHandler.java
@@ -1,9 +1,9 @@
 package com.hibit2.hibit2.auth.application;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
-import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 
 @Component
@@ -17,14 +17,13 @@ public class AuthTokenResponseHandler {
     }
 
     public void setRefreshTokenCookie(String refreshToken) {
-        Cookie refreshTokenCookie = new Cookie("refreshToken", refreshToken);
-        // HttpOnly 설정시 클라이언트에서 쿠키에 직접 js 코드로 접근이 불가능하고
-        // 이는 refreshToken 유효성 검사시 서버의 네트워크 통신을 한번 더 요구하고 추가 API 작성 및 클라이언트 OAuth 로직에서 복잡성을 유발하여
-        // 현 기준(23.08.19)상 HttpOnly 옵션은 일단 사용을 안하는 것으로 결정
-        refreshTokenCookie.setHttpOnly(true);
-        refreshTokenCookie.setSecure(true); // https 옵션 설정
-        refreshTokenCookie.setMaxAge(14 * 24 * 60 * 60); // 리프레시 토큰 유효 기간 설정 (14일)
-        refreshTokenCookie.setPath("/"); // 쿠키의 유효 경로 설정 (애플리케이션 전체)
-        httpServletResponse.addCookie(refreshTokenCookie);
+        ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", refreshToken)
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")  // SameSite 설정을 None으로 추가
+                .maxAge(14 * 24 * 60 * 60) // 리프레시 토큰 유효 기간 설정 (14일)
+                .path("/") // 쿠키의 유효 경로 설정 (애플리케이션 전체)
+                .build();
+        httpServletResponse.addHeader("Set-Cookie", refreshTokenCookie.toString());
     }
 }


### PR DESCRIPTION
- [x] 🙆🏻 PR 제목 형식은 지켰는가? ex. `[feat] 소셜로그인 기능을 구현한다.`
- [x] ✅ 빌드는 성공했나?
- [x] 🧹 불필요한 코드는 제거했나?
- [x] 💭 이슈는 등록했는가?
- [x] 🔖 라벨은 등록했나? ex. `feat`, `devops`

## 에러 발생 내용
최근 크롬 정책에 의해 서로 다른 도메인에서의 호출, 즉 SameSite 가 아닌 상태에서의 호출은 브라우저에서 막고 있습니다.

메세제를 보면 브라우저 기본으로 SameSite 값은 Lax로 설정되어있어서 다른 사이트에서 온 요청에 의한 Cookie 설정은 막는다고 되어 있습니다.

## 해결 과정
따라서, 해당 에러를 해결하기 위해 기본적으로 설정되어 있는 SameSite 값인 Lax를 None으로 바꾼다면 다른 사이트에서 온 요청에 대한 Set-Cookie 설정을 허용해줄 수 있습니다.

- [x] AuthTokenResponseHandler 클래스에서 기존 Cookie를 ResponseCookie 형으로 수정했습니다.
  - ResponseCookie는 스프링 프레임워크에서 제공하고 있으며, HttpCookie로부터 상속받고 있습니다.

## 결과
SameSite 값인 Lax를 None으로 바꾼 이후에 Set-Cookie 설정을 허용해주면서 경고창이 뜨지 않았고, 로그아웃도 정상적으로 완료되었습니다.

로그아웃을 한 이후에 다시 로그인할 때, 기존 리프레스 토큰 값을 이용하여 새로운 액세스 토큰 발급하는 과정까지 정상적으로 처리 완료했습니다

## 참고자료
- https://github.com/woorifisa-projects/GoodFriends/pull/310